### PR TITLE
Untitled

### DIFF
--- a/_build/data/properties.inc.php
+++ b/_build/data/properties.inc.php
@@ -279,5 +279,12 @@ $properties = array(
         'options' => '',
         'value' => '',
     ),
+    array(
+        'name' => 'permissions',
+        'desc' => '',
+        'type' => 'textfield',
+        'options' => '',
+        'value' => 'list',
+    ),
 );
 return $properties;

--- a/core/components/wayfinder/wayfinder.class.php
+++ b/core/components/wayfinder/wayfinder.class.php
@@ -66,6 +66,7 @@ class Wayfinder {
             'textOfLinks' => 'menutitle',
             'titleOfLinks' => 'pagetitle',
             'displayStart' => false,
+			'permissions' => 'list',
         ),$config);
 
         if (isset($config['sortOrder'])) {
@@ -476,6 +477,7 @@ class Wayfinder {
             $resultIds = array();
 
             foreach ($result as $doc)  {
+				if ((!empty($this->_config['permissions'])) && (!$doc->checkPolicy($this->_config['permissions']))) continue;
                 $tempDocInfo = $doc->toArray();
                 $resultIds[] = $tempDocInfo['id'];
                 $tempDocInfo['content'] = $tempDocInfo['class_key'] == 'modWebLink' ? $tempDocInfo['content'] : '';


### PR DESCRIPTION
wasn't sure if to leave the default as '' or set to 'list'
performance-wise - '' is better,  but i think the 'list' is correct (to the modx methodology)
change it if you wish.

note - how did I come to all of this?
1. (anonymous) granted 'load' on 'members only' pages (to get 401 and not 404)
2. as a result -  restricted pages are also rendered in wayfinder
