### PR TITLE
Add every parameter prefixed with an underscore to the placeholder array...

### DIFF
--- a/core/components/wayfinder/wayfinder.class.php
+++ b/core/components/wayfinder/wayfinder.class.php
@@ -334,6 +334,13 @@ class Wayfinder {
         $placeholders['wf.subitemcount'] = $numChildren;
         $placeholders['wf.attributes'] = $resource['link_attributes'];
 		
+        // Add every parameter prefixed with an underscore to the placeholder array
+        foreach ($this->_config as $key => $value){
+            if( $key[0] == '_' ) {
+              $placeholders["wf.$key"] = $this->_config[$key];
+            }
+        }		
+		
         if (!empty($this->tvList)) {
             $usePlaceholders = array_merge($placeholders,$this->placeHolders['tvs']);
             foreach ($this->tvList as $tvName) {


### PR DESCRIPTION
...

This is usefull to pass special parameters towards snippets that are called within a wayfinder template

Example: 
[[Wayfinder?
&startId=`1`
&level=`1`
&_getImageListTpl=`some Tpl`
]]

  [[!getImageList?
    &docid=`[[+wf.docid]]`
    &tvname=`someMIGx TV`
    &tpl=`[[+wf._getImageListTpl]]`
  ]]
