### PR TITLE
make use of link_tag_scheme system setting

### DIFF
--- a/core/components/wayfinder/wayfinder.class.php
+++ b/core/components/wayfinder/wayfinder.class.php
@@ -639,7 +639,7 @@ class Wayfinder {
                 $resultIds[] = $tempDocInfo['id'];
                 $tempDocInfo['content'] = $tempDocInfo['class_key'] == 'modWebLink' ? $tempDocInfo['content'] : '';
                 /* create the link */
-                $linkScheme = $this->_config['fullLink'] ? 'full' : '';
+                $linkScheme = $this->_config['fullLink'] ? 'full' : $this->modx->getOption('link_tag_scheme',null,'');
                 if (!empty($this->_config['scheme'])) $linkScheme = $this->_config['scheme'];
 
                 if ($this->_config['useWeblinkUrl'] !== 'false' && $tempDocInfo['class_key'] == 'modWebLink') {


### PR DESCRIPTION
If no link scheme is set in the config/snippet call, make use of the link_tag_scheme system setting instead of using "-1"
