### PR TITLE
remove [[++settings]] variables from match in findTemplateVars function

### DIFF
--- a/core/components/wayfinder/wayfinder.class.php
+++ b/core/components/wayfinder/wayfinder.class.php
@@ -808,7 +808,9 @@ class Wayfinder {
     }
 
     public function findTemplateVars($tpl) {
-        preg_match_all('~\[\[\+(.*?)\]\]~', $tpl, $matches);
+	# Intersel - 20190425 -remove [[++settings]] variables from match
+	#preg_match_all('~\[\[\+(.*?)\]\]~', $tpl, $matches);
+	preg_match_all('~\[\[\+([^\+].*?)\]\]~', $tpl, $matches);
         $TVs = array();
         foreach($matches[1] as $tv) {
             if (strpos($tv, "wf.") === false) {


### PR DESCRIPTION
as it creates bad entries ('+aVariable')  for the TVs array when the templates contains settings variables...
->change of the preg_match_all rule in findTemplateVars function